### PR TITLE
chore: improve CI — 3.12/3.13/3.14, fail-fast: false, pin deps, pip cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4
@@ -18,12 +19,13 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest pytest-django
+          pip install "pytest==8.1.1" "pytest-django==4.8.0"
           pip install -e .
 
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Closes #20

## Changes
- Drop Python 3.8 (EOL Oct 2024) and 3.9 (EOL Oct 2024) from matrix
- Add Python 3.12 (security), 3.13 (bugfix), and 3.14 (bugfix) — all currently active
- Add `fail-fast: false` so all matrix jobs always run to completion
- Pin `pytest==8.1.1` and `pytest-django==4.8.0` in CI to match `requirements_dev.txt`
- Add `cache: 'pip'` to `setup-python` to speed up runs

## Python version rationale (as of March 2026)
| Version | Status |
|---|---|
| 3.8 | EOL — dropped |
| 3.9 | EOL — dropped |
| 3.10 | Security fixes only — kept |
| 3.11 | Security fixes only — kept |
| 3.12 | Security fixes only — kept |
| 3.13 | Active bugfix — added |
| 3.14 | Active bugfix — added |

Co-authored-by: Jeffrey <info.jeffreyboisvert@gmail.com>
https://claude.ai/code/session_01GUmTC137fvj2ioL6TLfwgB